### PR TITLE
Add initial tests and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "node --experimental-test-module-mocks node_modules/tsx/dist/cli.mjs --test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/server/routes/health.test.ts
+++ b/server/routes/health.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+
+test('GET /api/health responds with status ok', async () => {
+  process.env.DATABASE_URL = 'postgres://user:pass@localhost/db';
+  process.env.SESSION_SECRET = 'secret';
+  process.env.OPENAI_API_KEY = 'key';
+  process.env.GMAIL_CLIENT_ID = 'id';
+  process.env.GMAIL_CLIENT_SECRET = 'secret';
+  process.env.GMAIL_REDIRECT_URI = 'uri';
+
+  const { registerRoutes } = await import('./index.ts');
+
+  const app = express();
+  app.use(express.json());
+  const server = await registerRoutes(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const port = (server.address() as any).port;
+
+  const res = await fetch(`http://localhost:${port}/api/health`);
+  const data = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(data, { status: 'ok' });
+
+  server.close();
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -45,6 +45,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   };
 
+  // Health check
+  app.get("/api/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
   // Dashboard
   app.get("/api/dashboard/stats", async (req, res) => {
     try {

--- a/server/utils/vite.test.ts
+++ b/server/utils/vite.test.ts
@@ -1,0 +1,12 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { log } from './vite';
+
+test('log outputs formatted message', () => {
+  const spy = mock.method(console, 'log');
+  log('hello world', 'tester');
+  assert.equal(spy.mock.calls.length, 1);
+  const [message] = spy.mock.calls[0].arguments;
+  assert.ok(message.includes('[tester] hello world'));
+  spy.mock.restore();
+});


### PR DESCRIPTION
## Summary
- add test script using Node's built-in test runner
- expose `/api/health` route for basic server verification
- create initial tests for health route and `log` utility
- run tests in CI workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689561ef128c8333988ebc63d58c5a36