### PR TITLE
Surface activity logging failures

### DIFF
--- a/client/src/components/dashboard/RecentLeads.tsx
+++ b/client/src/components/dashboard/RecentLeads.tsx
@@ -124,12 +124,13 @@ const MobileRecentLeads = () => {
       <CardContent className="space-y-2">
         <div className="overflow-x-auto">
           <div className="space-y-2 min-w-0">
-            <thead className="bg-gray-50">
-              <tr>
-                <th
-                  scope="col"
-                  className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase"
-                >
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th
+                    scope="col"
+                    className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase"
+                  >
                   Name
                 </th>
                 <th
@@ -233,8 +234,9 @@ const MobileRecentLeads = () => {
                   </td>
                 </tr>
               )}
-            </tbody>
-          </table>
+              </tbody>
+            </table>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Set required environment variables before importing modules
+process.env.DATABASE_URL = 'postgres://localhost/test';
+process.env.SESSION_SECRET = 'test';
+process.env.OPENAI_API_KEY = 'test';
+
+const { recordActivity } = await import('./index');
+const { storage } = await import('../config/storage');
+const { logger } = await import('../utils/logger');
+
+// Helper to replace storage.createActivity and logger.error during tests
+
+test('recordActivity surfaces errors to caller', async () => {
+  const err = new Error('boom');
+  const original = storage.createActivity;
+  // @ts-ignore override for test
+  storage.createActivity = async () => {
+    throw err;
+  };
+
+  try {
+    await assert.rejects(
+      recordActivity('u', 'action', 'entity', 1),
+      err
+    );
+  } finally {
+    // @ts-ignore restore
+    storage.createActivity = original;
+  }
+});
+
+test('callers can handle recordActivity errors', async () => {
+  const err = new Error('boom');
+  const originalActivity = storage.createActivity;
+  // @ts-ignore override for test
+  storage.createActivity = async () => {
+    throw err;
+  };
+
+  const logs: any[] = [];
+  const originalLogger = logger.error;
+  // @ts-ignore override logger
+  logger.error = (...args: any[]) => {
+    logs.push(args);
+  };
+
+  try {
+    await recordActivity('u', 'action', 'entity', 1).catch((error) =>
+      logger.error('Failed to record activity', error)
+    );
+    assert.equal(logs.length, 1);
+  } finally {
+    // @ts-ignore restore
+    storage.createActivity = originalActivity;
+    // @ts-ignore restore
+    logger.error = originalLogger;
+  }
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,7 +15,23 @@ import {
 } from "@shared/schema";
 import * as aiService from "../services/ai";
 import { GmailService } from "../services/gmailService";
+import { logger } from "../utils/logger";
 
+export async function recordActivity(
+  userId: string,
+  action: string,
+  entityType: string,
+  entityId: number,
+  details?: any
+) {
+  await storage.createActivity({
+    userId,
+    action,
+    entityType,
+    entityId,
+    details: details || null,
+  });
+}
 export async function registerRoutes(app: Express): Promise<Server> {
   // Initialize Gmail service
   const gmailService = new GmailService();
@@ -27,21 +43,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
       next();
     } catch (error) {
       res.status(400).json({ message: "Invalid request body", errors: error });
-    }
-  };
-
-  // Helper for recording activities
-  const recordActivity = async (userId: string, action: string, entityType: string, entityId: number, details?: any) => {
-    try {
-      await storage.createActivity({
-        userId,
-        action,
-        entityType,
-        entityId,
-        details: details || null,
-      });
-    } catch (error) {
-      console.error("Failed to record activity:", error);
     }
   };
 
@@ -77,7 +78,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "lead",
           lead.id,
           { companyName: lead.companyName }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(201).json(lead);
@@ -151,7 +152,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "lead",
           lead.id,
           { changes: req.validatedBody }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(lead);
@@ -176,7 +177,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "delete",
           "lead",
           id
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();
@@ -212,7 +213,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "lead",
           leadId,
           { tagId, tagName: tag.name }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();
@@ -247,7 +248,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "project",
           project.id,
           { name: project.name }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(201).json(project);
@@ -332,7 +333,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "project",
           project.id,
           { changes: req.validatedBody }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(project);
@@ -357,7 +358,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "delete",
           "project",
           id
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();
@@ -417,7 +418,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "client",
           client.id,
           { companyName: client.companyName }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(201).json(client);
@@ -493,7 +494,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "client",
           client.id,
           { changes: req.validatedBody }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(client);
@@ -518,7 +519,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "delete",
           "client",
           id
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();
@@ -578,7 +579,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "task",
           task.id,
           { title: task.title }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(201).json(task);
@@ -649,7 +650,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "task",
           task.id,
           { changes: req.validatedBody }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(task);
@@ -674,7 +675,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "delete",
           "task",
           id
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();
@@ -734,7 +735,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "dev_plan",
           devPlan.id,
           { name: devPlan.name, projectId: devPlan.projectId }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(201).json(devPlan);
@@ -805,7 +806,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "dev_plan",
           devPlan.id,
           { changes: req.validatedBody }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(devPlan);
@@ -847,7 +848,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "dev_plan",
           devPlan.id,
           { stage, startDate, endDate }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(devPlan);
@@ -873,7 +874,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "dev_plan",
           id,
           {}
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();
@@ -1144,7 +1145,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "delivery",
           delivery.id,
           { clientName: delivery.clientName }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(201).json(delivery);
@@ -1202,7 +1203,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "delivery",
           delivery.id,
           { changes: req.validatedBody }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(delivery);
@@ -1229,7 +1230,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "delivery",
           id,
           {}
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();
@@ -1252,7 +1253,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "automation",
           automation.id,
           { name: automation.name }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(201).json(automation);
@@ -1311,7 +1312,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "automation",
           automation.id,
           { changes: req.validatedBody }
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.json(automation);
@@ -1338,7 +1339,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           "automation",
           id,
           {}
-        );
+        ).catch((error) => logger.error("Failed to record activity", error));
       }
       
       res.status(204).end();


### PR DESCRIPTION
## Summary
- Refactor `recordActivity` to rethrow errors and export helper for reuse
- Log failures at call sites so activity write errors aren't swallowed
- Add unit tests verifying failed activity writes reject and are catchable

## Testing
- `npm test`
- `npm run check` *(fails: client/src/components/dashboard/RecentLeads.tsx: Expected corresponding JSX closing tag for 'div')*

------
https://chatgpt.com/codex/tasks/task_e_689561edd648833398621d16892694a7