### PR TITLE
Handle loading and error states on export page

### DIFF
--- a/client/src/components/dashboard/RecentLeads.tsx
+++ b/client/src/components/dashboard/RecentLeads.tsx
@@ -123,7 +123,7 @@ const MobileRecentLeads = () => {
       </CardHeader>
       <CardContent className="space-y-2">
         <div className="overflow-x-auto">
-          <div className="space-y-2 min-w-0">
+          <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
                 <th

--- a/client/src/pages/ExportPage.tsx
+++ b/client/src/pages/ExportPage.tsx
@@ -16,7 +16,7 @@ export default function ExportPage() {
   const [dateRange, setDateRange] = useState<'all' | '30' | '90' | '365'>('all');
 
   // Get data counts for display
-  const { data: stats } = useQuery({
+  const { data: stats, isLoading, error } = useQuery({
     queryKey: ["/api/dashboard/stats"],
   });
 
@@ -49,6 +49,26 @@ export default function ExportPage() {
       });
     },
   });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center text-red-500 py-10">
+        Error loading export data.
+      </div>
+    );
+  }
+
+  if (!stats) {
+    return null;
+  }
 
   const modules = [
     {


### PR DESCRIPTION
## Summary
- handle loading and error states when fetching export stats
- fix mis-tagged markup in RecentLeads component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689561e8ce6c833388b86ddad1af795d