### PR TITLE
refactor: use shared logger for activity errors

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,11 +2,11 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "../config/storage";
 import { z } from "zod";
-import { 
-  insertLeadSchema, 
-  insertProjectSchema, 
-  insertClientSchema, 
-  insertTaskSchema, 
+import {
+  insertLeadSchema,
+  insertProjectSchema,
+  insertClientSchema,
+  insertTaskSchema,
   insertTagSchema,
   insertActivitySchema,
   insertDevPlanSchema,
@@ -15,6 +15,7 @@ import {
 } from "@shared/schema";
 import * as aiService from "../services/ai";
 import { GmailService } from "../services/gmailService";
+import { logger } from "../utils/logger";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Initialize Gmail service
@@ -41,7 +42,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         details: details || null,
       });
     } catch (error) {
-      console.error("Failed to record activity:", error);
+      logger.error("Failed to record activity", { error, userId, action });
     }
   };
 


### PR DESCRIPTION
## Summary
- import shared logger for route utilities
- log activity record failures with structured metadata instead of console.error

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run check` *(fails: client/src/components/dashboard/RecentLeads.tsx(237,13): Expected corresponding JSX closing tag for 'div')*

------
https://chatgpt.com/codex/tasks/task_e_689561e4ad688333b5e1a24f6cc5cf74