### PR TITLE
refactor: use centralized logger

### DIFF
--- a/client/src/components/ai/TaskSuggestions.tsx
+++ b/client/src/components/ai/TaskSuggestions.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api, apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { Project } from "@shared/schema";
+import { logger } from "../../../../server/utils/logger";
 import { 
   Card, 
   CardContent, 
@@ -39,7 +40,7 @@ export const TaskSuggestions = ({ project, onAddTask }: TaskSuggestionsProps) =>
           description: `Generated ${data.tasks.length} task suggestions for this project`,
         });
       } else {
-        console.error("Unexpected response format:", data);
+        logger.error("Unexpected response format:", data);
         toast({
           title: "Error",
           description: "Received unexpected response format from AI service",
@@ -49,7 +50,7 @@ export const TaskSuggestions = ({ project, onAddTask }: TaskSuggestionsProps) =>
       setIsLoading(false);
     },
     onError: (error) => {
-      console.error("Error generating task suggestions:", error);
+      logger.error("Error generating task suggestions:", error);
       toast({
         title: "Error",
         description: `Failed to generate task suggestions: ${error.message}`,

--- a/client/src/components/modules/clients/ClientForm.tsx
+++ b/client/src/components/modules/clients/ClientForm.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { api, apiRequest, queryClient } from "@/lib/queryClient";
 import { useLocation } from "wouter";
+import { logger } from "../../../../../server/utils/logger";
 
 import {
   Form,
@@ -101,7 +102,7 @@ export const ClientForm = ({ client, isEdit = false, leadId }: ClientFormProps) 
             details: { clientId: response.id }
           });
         } catch (error) {
-          console.error("Error creating project from lead:", error);
+          logger.error("Error creating project from lead:", error);
         }
       }
       

--- a/client/src/components/modules/devplans/DevPlanBlockers.tsx
+++ b/client/src/components/modules/devplans/DevPlanBlockers.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { AlertTriangleIcon, RefreshCwIcon } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
+import { logger } from "../../../../../server/utils/logger";
 
 interface DevPlanBlockersProps {
   project: Project;
@@ -32,7 +33,7 @@ export const DevPlanBlockers = ({ project, tasks = [], devPlan }: DevPlanBlocker
         description: "Potential blockers have been identified.",
       });
     } catch (error) {
-      console.error("Error analyzing blockers:", error);
+      logger.error("Error analyzing blockers:", error);
       toast({
         title: "Analysis failed",
         description: "There was a problem identifying blockers.",

--- a/client/src/components/modules/devplans/DevPlanForm.tsx
+++ b/client/src/components/modules/devplans/DevPlanForm.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "wouter";
 import { insertDevPlanSchema, type DevPlan, type Project } from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { logger } from "../../../../../server/utils/logger";
 
 // UI components
 import {
@@ -165,7 +166,7 @@ export const DevPlanForm = ({ projects, initialData, onSuccess }: DevPlanFormPro
         onSuccess();
       }
     } catch (error) {
-      console.error("Error saving development plan:", error);
+      logger.error("Error saving development plan:", error);
       toast({
         title: "Error",
         description: "There was a problem saving the development plan.",

--- a/client/src/components/modules/devplans/DevPlanProgress.tsx
+++ b/client/src/components/modules/devplans/DevPlanProgress.tsx
@@ -6,11 +6,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { 
-  ClipboardList, 
-  Hammer, 
-  FileEdit, 
-  Rocket, 
+import {
+  ClipboardList,
+  Hammer,
+  FileEdit,
+  Rocket,
   ChevronRight,
   Calendar,
   ClipboardCheck,
@@ -19,6 +19,7 @@ import {
 import { apiRequest } from "@/lib/queryClient";
 import { format, differenceInDays, isBefore, isAfter } from "date-fns";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { logger } from "../../../../../server/utils/logger";
 
 interface DevPlanProgressProps {
   project: Project;
@@ -40,7 +41,7 @@ export const DevPlanProgress = ({ project, onUpdateStage }: DevPlanProgressProps
   // Error handling
   useEffect(() => {
     if (error) {
-      console.error("Error fetching dev plan:", error);
+      logger.error("Error fetching dev plan:", error);
     }
   }, [error]);
 
@@ -209,7 +210,7 @@ export const DevPlanProgress = ({ project, onUpdateStage }: DevPlanProgressProps
         onUpdateStage(updatedPlan);
       }
     } catch (error) {
-      console.error("Error updating stage:", error);
+      logger.error("Error updating stage:", error);
       toast({
         title: "Error",
         description: "Failed to update development stage.",

--- a/server/api/export.ts
+++ b/server/api/export.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { db } from "../config/db";
 import { tasks, leads, projects, clients } from "@shared/schema";
+import { logger } from "../utils/logger";
 
 const router = Router();
 
@@ -65,7 +66,7 @@ router.post("/", async (req, res) => {
       res.json(data);
     }
   } catch (error) {
-    console.error("Error exporting data:", error);
+    logger.error("Error exporting data:", error);
     res.status(500).json({ message: "Failed to export data" });
   }
 });

--- a/server/api/podcast-episodes.ts
+++ b/server/api/podcast-episodes.ts
@@ -3,6 +3,7 @@ import { db } from "../config/db";
 import { podcastEpisodes } from "@shared/schema";
 import { eq, desc } from "drizzle-orm";
 import { z } from "zod";
+import { logger } from "../utils/logger";
 
 const router = Router();
 
@@ -26,7 +27,7 @@ router.get("/", async (req, res) => {
     const episodes = await db.select().from(podcastEpisodes).orderBy(desc(podcastEpisodes.createdAt));
     res.json(episodes);
   } catch (error) {
-    console.error("Error fetching episodes:", error);
+    logger.error("Error fetching episodes:", error);
     res.status(500).json({ message: "Failed to fetch episodes" });
   }
 });
@@ -41,7 +42,7 @@ router.post("/", async (req, res) => {
     }).returning();
     res.status(201).json(newEpisode);
   } catch (error) {
-    console.error("Error creating episode:", error);
+    logger.error("Error creating episode:", error);
     res.status(500).json({ message: "Failed to create episode" });
   }
 });
@@ -64,7 +65,7 @@ router.patch("/:id", async (req, res) => {
     
     res.json(updatedEpisode);
   } catch (error) {
-    console.error("Error updating episode:", error);
+    logger.error("Error updating episode:", error);
     res.status(500).json({ message: "Failed to update episode" });
   }
 });

--- a/server/api/tasks.ts
+++ b/server/api/tasks.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { db } from "../config/db";
 import { tasks, insertTaskSchema } from "@shared/schema";
 import { eq, and, isNull, desc } from "drizzle-orm";
+import { logger } from "../utils/logger";
 
 const router = Router();
 
@@ -11,7 +12,7 @@ router.get("/", async (req, res) => {
     const allTasks = await db.select().from(tasks).orderBy(desc(tasks.createdAt));
     res.json(allTasks);
   } catch (error) {
-    console.error("Error fetching tasks:", error);
+    logger.error("Error fetching tasks:", error);
     res.status(500).json({ message: "Failed to fetch tasks" });
   }
 });
@@ -35,7 +36,7 @@ router.get("/due-soon", async (req, res) => {
     
     res.json(dueSoonTasks);
   } catch (error) {
-    console.error("Error fetching due soon tasks:", error);
+    logger.error("Error fetching due soon tasks:", error);
     res.status(500).json({ message: "Failed to fetch due soon tasks" });
   }
 });
@@ -52,7 +53,7 @@ router.get("/:id", async (req, res) => {
     
     res.json(task[0]);
   } catch (error) {
-    console.error("Error fetching task:", error);
+    logger.error("Error fetching task:", error);
     res.status(500).json({ message: "Failed to fetch task" });
   }
 });
@@ -64,7 +65,7 @@ router.post("/", async (req, res) => {
     const [newTask] = await db.insert(tasks).values(validated).returning();
     res.status(201).json(newTask);
   } catch (error) {
-    console.error("Error creating task:", error);
+    logger.error("Error creating task:", error);
     res.status(500).json({ message: "Failed to create task" });
   }
 });
@@ -97,7 +98,7 @@ router.patch("/:id", async (req, res) => {
     
     res.json(updatedTask);
   } catch (error) {
-    console.error("Error updating task:", error);
+    logger.error("Error updating task:", error);
     res.status(500).json({ message: "Failed to update task" });
   }
 });
@@ -109,7 +110,7 @@ router.delete("/:id", async (req, res) => {
     await db.delete(tasks).where(eq(tasks.id, taskId));
     res.status(204).send();
   } catch (error) {
-    console.error("Error deleting task:", error);
+    logger.error("Error deleting task:", error);
     res.status(500).json({ message: "Failed to delete task" });
   }
 });

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -15,6 +15,7 @@ import {
 } from "@shared/schema";
 import * as aiService from "../services/ai";
 import { GmailService } from "../services/gmailService";
+import { logger } from "../utils/logger";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Initialize Gmail service
@@ -41,7 +42,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         details: details || null,
       });
     } catch (error) {
-      console.error("Failed to record activity:", error);
+      logger.error("Failed to record activity:", error);
     }
   };
 
@@ -310,7 +311,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(blockers);
     } catch (error) {
-      console.error("Error analyzing project blockers:", error);
+      logger.error("Error analyzing project blockers:", error);
       res.status(500).json({ message: "Failed to analyze project blockers" });
     }
   });
@@ -942,7 +943,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const suggestions = await aiService.generateTaskSuggestions(projectDescription, projectName);
       res.json(suggestions);
     } catch (error) {
-      console.error("Error generating task suggestions:", error);
+      logger.error("Error generating task suggestions:", error);
       res.status(500).json({ message: "Failed to generate task suggestions" });
     }
   });
@@ -957,7 +958,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const processed = await aiService.processNaturalLanguageUpdate(taskId, currentStatus, update);
       res.json(processed);
     } catch (error) {
-      console.error("Error processing natural language update:", error);
+      logger.error("Error processing natural language update:", error);
       res.status(500).json({ message: "Failed to process natural language update" });
     }
   });
@@ -972,7 +973,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const insights = await aiService.generateClientInsights(clientData);
       res.json(insights);
     } catch (error) {
-      console.error("Error generating client insights:", error);
+      logger.error("Error generating client insights:", error);
       res.status(500).json({ message: "Failed to generate client insights" });
     }
   });
@@ -987,7 +988,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const prospects = await aiService.searchProspectiveClients(industry, criteria);
       res.json(prospects);
     } catch (error) {
-      console.error("Error searching for prospective clients:", error);
+      logger.error("Error searching for prospective clients:", error);
       res.status(500).json({ message: "Failed to search for prospective clients" });
     }
   });
@@ -1002,7 +1003,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const insights = await aiService.generateDashboardInsights(req.body);
       res.json(insights);
     } catch (error) {
-      console.error("Error generating dashboard insights:", error);
+      logger.error("Error generating dashboard insights:", error);
       res.status(500).json({ message: "Failed to generate dashboard insights" });
     }
   });
@@ -1017,7 +1018,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const advice = await aiService.getTaskAdvice(taskDescription, taskStatus);
       res.json(advice);
     } catch (error) {
-      console.error("Error getting task advice:", error);
+      logger.error("Error getting task advice:", error);
       res.status(500).json({ message: "Failed to get task advice" });
     }
   });
@@ -1028,7 +1029,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const status = await gmailService.getConnectionStatus();
       res.json(status);
     } catch (error) {
-      console.error("Gmail status error:", error);
+      logger.error("Gmail status error:", error);
       res.json({ connected: false, errorMessage: "Unable to check Gmail connection" });
     }
   });
@@ -1038,7 +1039,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const authUrl = await gmailService.getAuthUrl();
       res.json({ authUrl });
     } catch (error) {
-      console.error("Gmail auth error:", error);
+      logger.error("Gmail auth error:", error);
       res.status(500).json({ message: "Failed to generate auth URL" });
     }
   });
@@ -1053,7 +1054,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       await gmailService.handleAuthCallback(code as string);
       res.redirect("/dashboard?gmail=connected");
     } catch (error) {
-      console.error("Gmail callback error:", error);
+      logger.error("Gmail callback error:", error);
       res.status(500).json({ message: "Failed to handle auth callback" });
     }
   });
@@ -1063,7 +1064,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       await gmailService.syncEmails();
       res.json({ message: "Email sync completed" });
     } catch (error) {
-      console.error("Gmail sync error:", error);
+      logger.error("Gmail sync error:", error);
       res.status(500).json({ message: "Failed to sync emails" });
     }
   });
@@ -1074,7 +1075,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const emails = await storage.getEmails();
       res.json(emails);
     } catch (error) {
-      console.error("Get emails error:", error);
+      logger.error("Get emails error:", error);
       res.status(500).json({ message: "Failed to fetch emails" });
     }
   });
@@ -1084,7 +1085,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const stats = await storage.getEmailStats();
       res.json(stats);
     } catch (error) {
-      console.error("Get email stats error:", error);
+      logger.error("Get email stats error:", error);
       res.status(500).json({ message: "Failed to fetch email stats" });
     }
   });
@@ -1094,7 +1095,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const emails = await storage.getEmailsNeedingResponse();
       res.json(emails);
     } catch (error) {
-      console.error("Get emails needing response error:", error);
+      logger.error("Get emails needing response error:", error);
       res.status(500).json({ message: "Failed to fetch emails needing response" });
     }
   });
@@ -1105,7 +1106,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const revenues = await storage.getRevenues();
       res.json(revenues);
     } catch (error) {
-      console.error("Get revenues error:", error);
+      logger.error("Get revenues error:", error);
       res.status(500).json({ message: "Failed to fetch revenues" });
     }
   });
@@ -1115,7 +1116,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const metrics = await storage.getRevenueMetrics();
       res.json(metrics);
     } catch (error) {
-      console.error("Get revenue metrics error:", error);
+      logger.error("Get revenue metrics error:", error);
       res.status(500).json({ message: "Failed to fetch revenue metrics" });
     }
   });
@@ -1126,7 +1127,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const reports = await storage.getReports();
       res.json(reports);
     } catch (error) {
-      console.error("Get reports error:", error);
+      logger.error("Get reports error:", error);
       res.status(500).json({ message: "Failed to fetch reports" });
     }
   });
@@ -1149,7 +1150,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.status(201).json(delivery);
     } catch (error) {
-      console.error("Create delivery error:", error);
+      logger.error("Create delivery error:", error);
       res.status(500).json({ message: "Failed to create delivery" });
     }
   });
@@ -1164,7 +1165,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const deliveries = await storage.getDeliveries(filters);
       res.json(deliveries);
     } catch (error) {
-      console.error("Get deliveries error:", error);
+      logger.error("Get deliveries error:", error);
       res.status(500).json({ message: "Failed to fetch deliveries" });
     }
   });
@@ -1180,7 +1181,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(delivery);
     } catch (error) {
-      console.error("Get delivery error:", error);
+      logger.error("Get delivery error:", error);
       res.status(500).json({ message: "Failed to fetch delivery" });
     }
   });
@@ -1207,7 +1208,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(delivery);
     } catch (error) {
-      console.error("Update delivery error:", error);
+      logger.error("Update delivery error:", error);
       res.status(500).json({ message: "Failed to update delivery" });
     }
   });
@@ -1234,7 +1235,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.status(204).end();
     } catch (error) {
-      console.error("Delete delivery error:", error);
+      logger.error("Delete delivery error:", error);
       res.status(500).json({ message: "Failed to delete delivery" });
     }
   });
@@ -1257,7 +1258,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.status(201).json(automation);
     } catch (error) {
-      console.error("Create automation error:", error);
+      logger.error("Create automation error:", error);
       res.status(500).json({ message: "Failed to create automation" });
     }
   });
@@ -1273,7 +1274,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const automations = await storage.getAutomations(filters);
       res.json(automations);
     } catch (error) {
-      console.error("Get automations error:", error);
+      logger.error("Get automations error:", error);
       res.status(500).json({ message: "Failed to fetch automations" });
     }
   });
@@ -1289,7 +1290,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(automation);
     } catch (error) {
-      console.error("Get automation error:", error);
+      logger.error("Get automation error:", error);
       res.status(500).json({ message: "Failed to fetch automation" });
     }
   });
@@ -1316,7 +1317,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(automation);
     } catch (error) {
-      console.error("Update automation error:", error);
+      logger.error("Update automation error:", error);
       res.status(500).json({ message: "Failed to update automation" });
     }
   });
@@ -1343,7 +1344,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.status(204).end();
     } catch (error) {
-      console.error("Delete automation error:", error);
+      logger.error("Delete automation error:", error);
       res.status(500).json({ message: "Failed to delete automation" });
     }
   });
@@ -1354,7 +1355,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const stats = await storage.getPipelineStats();
       res.json(stats);
     } catch (error) {
-      console.error("Get pipeline stats error:", error);
+      logger.error("Get pipeline stats error:", error);
       res.status(500).json({ message: "Failed to fetch pipeline stats" });
     }
   });

--- a/server/services/ai.ts
+++ b/server/services/ai.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 import { storage } from "../config/storage";
 import { env } from "../config/env";
+import { logger } from "../utils/logger";
 
 // The newest OpenAI model is "gpt-4o" which was released May 13, 2024. do not change this unless explicitly requested by the user
 const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
@@ -39,7 +40,7 @@ export async function generateTaskSuggestions(projectDescription: string, projec
     
     return JSON.parse(content);
   } catch (error) {
-    console.error("Error generating task suggestions:", error);
+    logger.error("Error generating task suggestions:", error);
     return { 
       tasks: [],
       error: "Failed to generate task suggestions. Please try again later."
@@ -101,7 +102,7 @@ export async function processNaturalLanguageUpdate(taskId: number, currentStatus
     
     return JSON.parse(content);
   } catch (error) {
-    console.error("Error processing natural language update:", error);
+    logger.error("Error processing natural language update:", error);
     return { 
       updates: {},
       error: "Failed to process natural language update. Please try again later."
@@ -143,7 +144,7 @@ export async function generateClientInsights(clientData: any) {
     
     return JSON.parse(content);
   } catch (error) {
-    console.error("Error generating client insights:", error);
+    logger.error("Error generating client insights:", error);
     return { 
       insights: "Unable to generate insights at this time. Please try again later.",
       error: error.message
@@ -186,7 +187,7 @@ export async function searchProspectiveClients(industry: string, criteria: strin
     
     return JSON.parse(content);
   } catch (error) {
-    console.error("Error searching prospective clients:", error);
+    logger.error("Error searching prospective clients:", error);
     return { 
       prospects: [],
       error: "Failed to search for prospective clients. Please try again later."
@@ -225,7 +226,7 @@ export async function getTaskAdvice(taskDescription: string, taskStatus: string,
     
     return JSON.parse(content);
   } catch (error) {
-    console.error("Error getting task advice:", error);
+    logger.error("Error getting task advice:", error);
     return { 
       advice: "Unable to generate advice at this time. Please try again later.",
       error: error.message
@@ -281,7 +282,7 @@ export async function generateDashboardInsights(dashboardData: any) {
     
     return JSON.parse(content);
   } catch (error: any) {
-    console.error("Error generating dashboard insights:", error);
+    logger.error("Error generating dashboard insights:", error);
     return { 
       priorities: [],
       summary: "Unable to generate insights at this time. Please try again later.",
@@ -353,7 +354,7 @@ export async function analyzeProjectBlockers(project: any, tasks: any[], devPlan
     const result = JSON.parse(content);
     return result.blockers || [];
   } catch (error) {
-    console.error("Error analyzing project blockers:", error);
+    logger.error("Error analyzing project blockers:", error);
     return [
       {
         description: "Unable to analyze project blockers at this time. Please try again later.",

--- a/server/utils/vite.ts
+++ b/server/utils/vite.ts
@@ -5,6 +5,7 @@ import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../../vite.config";
 import { nanoid } from "nanoid";
+import { logger } from "./logger";
 
 const viteLogger = createLogger();
 
@@ -16,7 +17,7 @@ export function log(message: string, source = "express") {
     hour12: true,
   });
 
-  console.log(`${formattedTime} [${source}] ${message}`);
+  logger.info(`${formattedTime} [${source}] ${message}`);
 }
 
 export async function setupVite(app: Express, server: Server) {


### PR DESCRIPTION
## Summary
- replace console.* calls with shared logger
- route backend and client-side components through logger
- enable timestamped log messages via pino logger

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json` (fails: client/src/components/dashboard/RecentLeads.tsx(237,13): error TS17002)
- `DATABASE_URL=postgres://localhost SESSION_SECRET=secret OPENAI_API_KEY=key node --import tsx -e "import('./server/utils/logger.ts').then(m=>{m.logger.info('info message'); m.logger.error('error message');})"`


------
https://chatgpt.com/codex/tasks/task_e_689561e0b0fc833382cba49adc1b96b9