### PR TITLE
feat: add Gmail ID email lookup

### DIFF
--- a/server/config/storage.ts
+++ b/server/config/storage.ts
@@ -127,6 +127,7 @@ export interface IStorage {
   
   // Emails
   createEmail(email: InsertEmail): Promise<Email>;
+  getEmailByGmailId(gmailId: string): Promise<Email | undefined>;
   getEmails(filters?: { context?: string; status?: string; limit?: number }): Promise<Email[]>;
   getEmailsNeedingResponse(): Promise<Email[]>;
   getEmailStats(): Promise<{
@@ -720,6 +721,14 @@ export class DatabaseStorage implements IStorage {
   async createEmail(email: InsertEmail): Promise<Email> {
     const [newEmail] = await db.insert(emails).values(email).returning();
     return newEmail;
+  }
+
+  async getEmailByGmailId(gmailId: string): Promise<Email | undefined> {
+    const [emailRecord] = await db
+      .select()
+      .from(emails)
+      .where(eq(emails.gmailId, gmailId));
+    return emailRecord;
   }
 
   async getEmails(filters?: { context?: string; status?: string; limit?: number }): Promise<Email[]> {

--- a/server/services/gmailService.ts
+++ b/server/services/gmailService.ts
@@ -124,11 +124,10 @@ export class GmailService {
       // Determine context and priority using AI
       const contextAnalysis = await this.analyzeEmailContext(subject, body, fromEmail);
       
-      // Check if email already exists (simple check - could be improved)
+      // Check if email already exists
       try {
-        const existingEmails = await storage.getEmails({ limit: 1000 });
-        const existingEmail = existingEmails.find(e => e.gmailId === messageId);
-        
+        const existingEmail = await storage.getEmailByGmailId(messageId);
+
         if (!existingEmail) {
         // Create email record
         const emailData: InsertEmail = {


### PR DESCRIPTION
## Summary
- add `getEmailByGmailId` to storage for indexed email retrieval
- use new lookup in Gmail service instead of fetching all emails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: client/src/components/dashboard/RecentLeads.tsx(237,13): error TS17002: Expected corresponding JSX closing tag for 'div'.)*

------
https://chatgpt.com/codex/tasks/task_e_689561dd114883339e38c925e48ea539