### PR TITLE
Use base64url encoding for Gmail messages

### DIFF
--- a/server/services/gmailService.test.ts
+++ b/server/services/gmailService.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Mock Gmail API and verify base64url encoding
+
+test('sendEmail encodes message with base64url', async () => {
+  process.env.DATABASE_URL = 'postgres://example.com/db';
+  process.env.SESSION_SECRET = 'secret';
+  process.env.OPENAI_API_KEY = 'testkey';
+
+  const { GmailService } = await import('./gmailService');
+
+  const service = new GmailService();
+  let receivedRaw: string | undefined;
+
+  // Mock the Gmail API send method
+  (service as any).gmail = {
+    users: {
+      messages: {
+        send: async ({ requestBody }: any) => {
+          receivedRaw = requestBody.raw;
+          return {};
+        },
+      },
+    },
+  };
+
+  await service.sendEmail('test@example.com', 'Hello', 'Body');
+
+  const message = ['To: test@example.com', 'Subject: Hello', '', 'Body'].join('\n');
+  const expected = Buffer.from(message).toString('base64url');
+
+  assert.strictEqual(receivedRaw, expected);
+});

--- a/server/services/gmailService.ts
+++ b/server/services/gmailService.ts
@@ -272,7 +272,7 @@ Respond with JSON: {
         body,
       ].join('\n');
 
-      const encodedMessage = Buffer.from(message).toString('base64');
+      const encodedMessage = Buffer.from(message).toString('base64url');
 
       await this.gmail.users.messages.send({
         userId: 'me',


### PR DESCRIPTION
## Summary
- Encode outgoing Gmail messages with `base64url` to match API requirements
- Add unit test with mocked Gmail API to verify `base64url` encoding is used

## Testing
- `npx tsx --test server/services/gmailService.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689561db99708333882fb6363c3a15d2