### PR TITLE
feat: centralize env vars for gmail and openai

### DIFF
--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -5,6 +5,10 @@ const envSchema = z.object({
   DATABASE_URL: z.string().url("DATABASE_URL must be a valid URL"),
   SESSION_SECRET: z.string().min(1, "SESSION_SECRET is required"),
   OPENAI_API_KEY: z.string().min(1, "OPENAI_API_KEY is required"),
+  GMAIL_CLIENT_ID: z.string().min(1, "GMAIL_CLIENT_ID is required"),
+  GMAIL_CLIENT_SECRET: z.string().min(1, "GMAIL_CLIENT_SECRET is required"),
+  GMAIL_REDIRECT_URI: z.string().url("GMAIL_REDIRECT_URI must be a valid URL"),
+  GMAIL_REFRESH_TOKEN: z.string().min(1).optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/server/services/gmailService.ts
+++ b/server/services/gmailService.ts
@@ -4,9 +4,10 @@ import { storage } from '../config/storage';
 import { emails, tasks, type InsertEmail, type InsertTask } from '@shared/schema';
 import { eq, and, desc } from 'drizzle-orm';
 import { logger } from '../utils/logger';
+import { env } from '../config/env';
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: env.OPENAI_API_KEY,
 });
 
 export class GmailService {
@@ -15,15 +16,15 @@ export class GmailService {
 
   constructor() {
     this.oauth2Client = new google.auth.OAuth2(
-      process.env.GMAIL_CLIENT_ID,
-      process.env.GMAIL_CLIENT_SECRET,
-      process.env.GMAIL_REDIRECT_URI
+      env.GMAIL_CLIENT_ID,
+      env.GMAIL_CLIENT_SECRET,
+      env.GMAIL_REDIRECT_URI
     );
 
     // Set credentials if we have a refresh token
-    if (process.env.GMAIL_REFRESH_TOKEN) {
+    if (env.GMAIL_REFRESH_TOKEN) {
       this.oauth2Client.setCredentials({
-        refresh_token: process.env.GMAIL_REFRESH_TOKEN,
+        refresh_token: env.GMAIL_REFRESH_TOKEN,
       });
     }
 


### PR DESCRIPTION
## Summary
- validate Gmail and OpenAI environment variables with zod
- consume Gmail and OpenAI keys from unified env module in gmailService

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Expected corresponding JSX closing tag for 'div')*

------
https://chatgpt.com/codex/tasks/task_e_689561da85848333bd7c3f13575fbb6a