### PR TITLE
test: add due date status tests

### DIFF
--- a/client/src/lib/utils/format.test.ts
+++ b/client/src/lib/utils/format.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getDueDateStatus } from "./format";
+
+test("overdue when date is before today", () => {
+  const result = getDueDateStatus(
+    new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  );
+  assert.equal(result.status, "overdue");
+});
+
+test("today when date is today", () => {
+  const result = getDueDateStatus(new Date().toISOString());
+  assert.equal(result.status, "today");
+});
+
+test("soon when date is within next 3 days", () => {
+  const result = getDueDateStatus(
+    new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString()
+  );
+  assert.equal(result.status, "soon");
+});
+
+test("normal when date is further out", () => {
+  const result = getDueDateStatus(
+    new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString()
+  );
+  assert.equal(result.status, "normal");
+});

--- a/client/src/lib/utils/format.ts
+++ b/client/src/lib/utils/format.ts
@@ -1,4 +1,10 @@
-import { format as formatDateFns, formatDistanceToNow, isToday, isPast, addDays } from "date-fns";
+import {
+  format as formatDateFns,
+  formatDistanceToNow,
+  isToday,
+  isPast,
+  differenceInCalendarDays,
+} from "date-fns";
 
 // Format date to display in a readable format
 export const formatDate = (date: Date | string | null | undefined): string => {
@@ -38,7 +44,8 @@ export const getDueDateStatus = (dueDate: string | null | undefined) => {
   if (isToday(date)) {
     return { status: "today", label: "Due today" };
   }
-  if (isPast(addDays(new Date(), 3), date)) {
+  const diff = differenceInCalendarDays(date, new Date());
+  if (diff > 0 && diff <= 3) {
     return { status: "soon", label: `Due ${formatDateFns(date, "MMM d")}` };
   }
   

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "node --import tsx --test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- fix `getDueDateStatus` to mark dates within the next three days as `soon`
- add tests for overdue, today, soon, and normal due date states
- add npm test script using Node's test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689556c76494833383f6c4a2f5ef349b