### PR TITLE
Use isBefore when detecting upcoming due dates

### DIFF
--- a/client/src/lib/utils/format.ts
+++ b/client/src/lib/utils/format.ts
@@ -1,4 +1,11 @@
-import { format as formatDateFns, formatDistanceToNow, isToday, isPast, addDays } from "date-fns";
+import {
+  format as formatDateFns,
+  formatDistanceToNow,
+  isToday,
+  isPast,
+  addDays,
+  isBefore,
+} from "date-fns";
 
 // Format date to display in a readable format
 export const formatDate = (date: Date | string | null | undefined): string => {
@@ -38,7 +45,7 @@ export const getDueDateStatus = (dueDate: string | null | undefined) => {
   if (isToday(date)) {
     return { status: "today", label: "Due today" };
   }
-  if (isPast(addDays(new Date(), 3), date)) {
+  if (isBefore(date, addDays(new Date(), 3))) {
     return { status: "soon", label: `Due ${formatDateFns(date, "MMM d")}` };
   }
   


### PR DESCRIPTION
## Summary
- use `isBefore` instead of `isPast` with two dates in `getDueDateStatus`
- import `isBefore` from `date-fns`

## Testing
- `npm run check` *(fails: client/src/components/dashboard/RecentLeads.tsx(237,13): error TS17002: Expected corresponding JSX closing tag for 'div')*
- `npx tsc client/src/lib/utils/format.ts`


------
https://chatgpt.com/codex/tasks/task_e_689556c4e29c8333bcf74e81a22031fd