### PR TITLE
Use base64url for Gmail API messages

### DIFF
--- a/server/services/gmailService.ts
+++ b/server/services/gmailService.ts
@@ -272,7 +272,7 @@ Respond with JSON: {
         body,
       ].join('\n');
 
-      const encodedMessage = Buffer.from(message).toString('base64');
+      const encodedMessage = Buffer.from(message).toString('base64url');
 
       await this.gmail.users.messages.send({
         userId: 'me',


### PR DESCRIPTION
## Summary
- Encode outgoing Gmail messages using base64url to meet Gmail API requirements

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689553573080833386be75bda17c3c37